### PR TITLE
fix: propagate duplex transform sink errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,11 +120,14 @@
   "license": "MIT",
   "devDependencies": {
     "aegir": "^36.1.3",
+    "delay": "^5.0.0",
     "it-all": "^1.0.6",
     "it-drain": "^1.0.5",
     "streaming-iterables": "^6.0.0"
   },
   "dependencies": {
+    "it-merge": "^1.0.4",
+    "it-pushable": "^2.0.0",
     "it-stream-types": "^1.0.3"
   },
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,9 +24,9 @@ export const isDuplex = <TSource, TSink = TSource, RSink = Promise<void>> (obj: 
 
 const duplexPipelineFn = <TSource> (duplex: any) => {
   return (source: any): it.Source<TSource> => {
-    const p = duplex.sink(source);
+    const p = duplex.sink(source)
 
-    if (p.then) {
+    if (p.then != null) {
       const stream = pushable<TSource>()
       p.then(() => {
         stream.end()
@@ -37,7 +37,7 @@ const duplexPipelineFn = <TSource> (duplex: any) => {
       return merge(stream, duplex.source)
     }
 
-    return duplex.source;
+    return duplex.source
   }
 }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -130,14 +130,17 @@ describe('it-pipe', () => {
     await expect(
       pipe(
         forever(), {
-          source: async function * () {
+          source: (async function * () {
             await delay(1000)
-          }(),
+            yield 5
+          }()),
           sink: async (source: Source<number>) => {
             await delay(20)
             throw err
           }
-        }, (source) => drain(source))
+        },
+        async (source) => await drain(source)
+      )
     ).to.eventually.be.rejected.with.property('message', err.message)
   })
 })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -7,12 +7,6 @@ import delay from 'delay'
 import type { Duplex, Source } from 'it-stream-types'
 
 const oneTwoThree = () => [1, 2, 3]
-const forever = async function * () {
-  while (true) {
-    yield Math.random()
-    await delay(1)
-  }
-}
 
 describe('it-pipe', () => {
   it('should pipe source', async () => {
@@ -129,7 +123,7 @@ describe('it-pipe', () => {
 
     await expect(
       pipe(
-        forever(), {
+        oneTwoThree, {
           source: (async function * () {
             await delay(1000)
             yield 5


### PR DESCRIPTION
Sink errors were either getting smothered or causing unhandled promise rejections depending on your platform.

This breaks on Chrome when creating an abortable-iterator from a duplex transform stream that you then try to abort.

Instead if the sink of a duplex stream being used as a transform returns a promise, propagate errors thrown by the sink into it's source so they can be caught and handled by the consumer.