### PR TITLE
fix: support goodbye sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "delay": "^5.0.0",
     "it-all": "^1.0.6",
     "it-drain": "^1.0.5",
+    "p-defer": "^4.0.0",
     "streaming-iterables": "^6.0.0"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export const isDuplex = <TSource, TSink = TSource, RSink = Promise<void>> (obj: 
   return obj != null && typeof obj.sink === 'function' && isIterable(obj.source)
 }
 
-const duplexPipelineFn = <TSource> (duplex: any) => {
+const duplexPipelineFn = <TSource> (duplex: it.Duplex<TSource>) => {
   return (source: any): it.Source<TSource> => {
     const p = duplex.sink(source)
 
@@ -34,7 +34,12 @@ const duplexPipelineFn = <TSource> (duplex: any) => {
         stream.end(err)
       })
 
-      return merge(stream, duplex.source)
+      const sourceWrap = async function * () {
+        yield * duplex.source
+        stream.end()
+      }
+
+      return merge(stream, sourceWrap())
     }
 
     return duplex.source


### PR DESCRIPTION
If the sink in a duplex does not end until the source ends, we need to end the pushable stream used to propagate errors when the source ends, otherwise the returned merged source never ends and everything hangs.