### PR TITLE
fix: correct sink duplex type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ const duplexPipelineFn = <TSource> (duplex: it.Duplex<TSource>) => {
 
 export type Source<A> = it.Source<A> | (() => it.Source<A>) | it.Duplex<A, any, any>
 export type Transform<A, B> = it.Transform<A, B> | it.Duplex<B, A, any>
-export type Sink<A, B> = it.Sink<A, B> | it.Duplex<A, any, B>
+export type Sink<A, B> = it.Sink<A, B> | it.Duplex<any, A, B>
 
 export function pipe<A> (
   first: Source<A>

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -177,10 +177,10 @@ describe('it-pipe', () => {
   it('should pipe to a duplex with a different source type to sink type', async () => {
     const data = [0, 1, 2, 3, 4]
     const collected = defer<number[]>()
-    const input: Source<number> = async function * () {
+    const input: Source<number> = (async function * () {
       await delay(1)
       yield * data
-    }()
+    }())
     const output: Duplex<string, number> = {
       source: ['hello', 'world'],
       sink: async (source) => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -173,4 +173,28 @@ describe('it-pipe', () => {
       }
     )
   })
+
+  it('should pipe to a duplex with a different source type to sink type', async () => {
+    const data = [0, 1, 2, 3, 4]
+    const collected = defer<number[]>()
+    const input: Source<number> = async function * () {
+      await delay(1)
+      yield * data
+    }()
+    const output: Duplex<string, number> = {
+      source: ['hello', 'world'],
+      sink: async (source) => {
+        collected.resolve(await all(source))
+      }
+    }
+
+    await pipe(
+      input,
+      output
+    )
+
+    const result = await collected.promise
+
+    expect(result).to.deep.equal(data)
+  })
 })


### PR DESCRIPTION
Use generics to derive the duplex's sink type, not the source type, when we are treating a duplex as a sink.

The added test fails to compile without the change to the Sink type.