### PR TITLE
fix!: do not create unnecessary async work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 node_modules
-coverage
-.nyc_output
-package-lock.json
+build
 dist
+.docs
+.coverage
+node_modules
+package-lock.json
+yarn.lock
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # it-pipe <!-- omit in toc -->
 
 [![codecov](https://img.shields.io/codecov/c/github/alanshaw/it-pipe.svg?style=flat-square)](https://codecov.io/gh/alanshaw/it-pipe)
-[![CI](https://img.shields.io/github/workflow/status/alanshaw/it-pipe/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/alanshaw/it-pipe/actions/workflows/js-test-and-release.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/alanshaw/it-pipe/js-test-and-release.yml?branch=master\&style=flat-square)](https://github.com/alanshaw/it-pipe/actions/workflows/js-test-and-release.yml?query=branch%3Amaster)
 
 > Utility to "pipe" async iterables together
 
 ## Table of contents <!-- omit in toc -->
 
 - [Install](#install)
+  - [Browser `<script>` tag](#browser-script-tag)
 - [Usage](#usage)
 - [API](#api)
   - [`pipe(firstFn, ...fns)`](#pipefirstfn-fns)
-- [Contribute](#contribute)
+- [API Docs](#api-docs)
 - [License](#license)
 - [Contribution](#contribution)
 
@@ -19,6 +20,14 @@
 
 ```console
 $ npm i it-pipe
+```
+
+### Browser `<script>` tag
+
+Loading this module through a script tag will make it's exports available as `ItPipe` in the global namespace.
+
+```html
+<script src="https://unpkg.com/it-pipe/dist/index.min.js"></script>
 ```
 
 Based on this definition of streaming iterables <https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9>.
@@ -65,9 +74,9 @@ Note:
 - `firstFn` may be a `Function` or an `Iterable`
 - `firstFn` or any of `fns` may be a [duplex object](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#duplex-it) (an object with a `sink` and `source`).
 
-## Contribute
+## API Docs
 
-Feel free to dive in! [Open an issue](https://github.com/alanshaw/it-pipe/issues/new) or submit PRs.
+- <https://alanshaw.github.io/it-pipe>
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "types": "./dist/src/index.d.ts",
   "files": [
     "src",
-    "dist/src",
+    "dist",
     "!dist/test",
     "!**/*.tsbuildinfo"
   ],
@@ -144,18 +144,20 @@
     "test:firefox-webworker": "aegir test -t webworker -- --browser firefox",
     "test:node": "aegir test -t node --cov",
     "test:electron-main": "aegir test -t electron-main",
-    "release": "aegir release"
+    "release": "aegir release",
+    "docs": "aegir docs"
   },
   "dependencies": {
-    "it-merge": "^2.0.0",
-    "it-pushable": "^3.1.0",
-    "it-stream-types": "^1.0.3"
+    "it-merge": "^3.0.0",
+    "it-pushable": "^3.1.0"
   },
   "devDependencies": {
-    "aegir": "^37.4.8",
+    "aegir": "^38.1.8",
     "delay": "^5.0.0",
-    "it-all": "^2.0.0",
-    "it-drain": "^2.0.0",
+    "it-all": "^3.0.0",
+    "it-drain": "^3.0.0",
+    "it-map": "^3.0.0",
+    "it-stream-types": "^1.0.3",
     "p-defer": "^4.0.0",
     "streaming-iterables": "^7.0.4"
   }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2,70 +2,355 @@ import { expect } from 'aegir/chai'
 import { pipe } from '../src/index.js'
 import all from 'it-all'
 import drain from 'it-drain'
+import map from 'it-map'
 import { filter, collect, consume } from 'streaming-iterables'
 import delay from 'delay'
 import defer from 'p-defer'
-import type { Duplex, Source } from 'it-stream-types'
+import type { Source } from 'it-stream-types'
+import type { Duplex } from '../src/index.js'
 
-const oneTwoThree = () => [1, 2, 3]
+const oneTwoThree = (): number[] => [1, 2, 3]
+
+const asyncOneTwoThree = async function * (): AsyncGenerator<number, void, undefined> {
+  yield * oneTwoThree()
+}
+
+type IsAny<T> = unknown extends T ? T extends {} ? T : never : never
+type NotAny<T> = T extends IsAny<T> ? never : T
+
+/**
+ * Utility function to assert that tsc has not derived the type of
+ * the passed argument as 'any'
+ */
+function assertNotAny<T> (x: NotAny<T>): void {
+
+}
+
+/**
+ * Utility function to assert that tsc has not derived the type of
+ * the passed argument as 'never'
+ */
+function assertNotNever (x: never): void {
+
+}
 
 describe('it-pipe', () => {
-  it('should pipe source', async () => {
-    const result = await pipe(oneTwoThree)
-    expect(result).to.deep.equal([1, 2, 3])
+  describe('one item pipeline', () => {
+    it('should pipe iterable source', () => {
+      const result = pipe(oneTwoThree())
+
+      // @ts-expect-error - result should not be assignable to never - if it is
+      // then we've broken the types and this comment with cause tsc to fail
+      assertNotNever(result)
+      assertNotAny(result)
+
+      expect(result[Symbol.iterator]).to.be.ok()
+      expect(result).to.deep.equal([1, 2, 3])
+    })
+
+    it('should pipe function source', () => {
+      const result = pipe(oneTwoThree)
+
+      // @ts-expect-error - result should not be assignable to never - if it is
+      // then we've broken the types and this comment with cause tsc to fail
+      assertNotNever(result)
+      assertNotAny(result)
+
+      expect(result[Symbol.iterator]).to.be.ok()
+      expect(result).to.deep.equal([1, 2, 3])
+    })
+
+    it('should pipe async iterable source', async () => {
+      const result = pipe(asyncOneTwoThree())
+
+      // @ts-expect-error - result should not be assignable to never - if it is
+      // then we've broken the types and this comment with cause tsc to fail
+      assertNotNever(result)
+      assertNotAny(result)
+
+      expect(result[Symbol.asyncIterator]).to.be.ok()
+      await expect(all(result)).to.eventually.deep.equal([1, 2, 3])
+    })
+
+    it('should pipe async function source', async () => {
+      const result = pipe(asyncOneTwoThree)
+
+      // @ts-expect-error - result should not be assignable to never - if it is
+      // then we've broken the types and this comment with cause tsc to fail
+      assertNotNever(result)
+      assertNotAny(result)
+
+      expect(result[Symbol.asyncIterator]).to.be.ok()
+      await expect(all(result)).to.eventually.deep.equal([1, 2, 3])
+    })
+
+    it('should allow single duplex', async () => {
+      const duplex: Duplex<number[], number[], string[]> = {
+        source: oneTwoThree(),
+        sink: (source) => {
+          return all(source).map(n => n.toString())
+        }
+      }
+
+      const result = pipe(
+        duplex
+      )
+
+      // @ts-expect-error - result should not be assignable to never
+      assertNotNever(result)
+      assertNotAny(result)
+
+      expect(result[Symbol.iterator]).to.be.ok()
+      expect(result).to.deep.equal(oneTwoThree())
+    })
+
+    it('should allow single async duplex', async () => {
+      const duplex: Duplex<AsyncGenerator<number>, AsyncGenerator<number>, AsyncGenerator<string>> = {
+        source: asyncOneTwoThree(),
+        sink: (source) => {
+          return map(source, n => n.toString())
+        }
+      }
+
+      const result = pipe(
+        duplex
+      )
+
+      // @ts-expect-error - result should not be assignable to never - if it is
+      // then we've broken the types and this comment with cause tsc to fail
+      assertNotNever(result)
+      assertNotAny(result)
+
+      expect(result[Symbol.asyncIterator]).to.be.ok()
+      await expect(all(result)).to.eventually.deep.equal(oneTwoThree())
+    })
   })
 
-  it('should pipe source -> sink', async () => {
-    const result = await pipe(oneTwoThree, all)
-    expect(result).to.deep.equal([1, 2, 3])
+  describe('two item pipeline', () => {
+    it('should pipe iterable source -> sink function', () => {
+      const result = pipe(
+        oneTwoThree(),
+        (source) => all(source)
+      )
+
+      // @ts-expect-error - result should not be assignable to never - if it is
+      // then we've broken the types and this comment with cause tsc to fail
+      assertNotNever(result)
+      assertNotAny(result)
+
+      expect(result).to.deep.equal([1, 2, 3])
+    })
+
+    it('should pipe iterable function source -> sink function', () => {
+      const result = pipe(
+        oneTwoThree,
+        (source) => all(source)
+      )
+
+      // @ts-expect-error - result should not be assignable to never - if it is
+      // then we've broken the types and this comment with cause tsc to fail
+      assertNotNever(result)
+      assertNotAny(result)
+
+      expect(result).to.deep.equal([1, 2, 3])
+    })
+
+    it('should pipe async iterable source -> sink function', async () => {
+      const result = await pipe(
+        asyncOneTwoThree(),
+        async (source) => await all(source)
+      )
+
+      // @ts-expect-error - result should not be assignable to never - if it is
+      // then we've broken the types and this comment with cause tsc to fail
+      assertNotNever(result)
+      assertNotAny(result)
+
+      expect(result).to.deep.equal([1, 2, 3])
+    })
+
+    it('should pipe async iterable function source -> sink function', async () => {
+      const result = await pipe(
+        asyncOneTwoThree,
+        async (source) => await all(source)
+      )
+
+      // @ts-expect-error - result should not be assignable to never - if it is
+      // then we've broken the types and this comment with cause tsc to fail
+      assertNotNever(result)
+      assertNotAny(result)
+
+      expect(result).to.deep.equal([1, 2, 3])
+    })
   })
 
-  it('should pipe source -> transform -> sink', async () => {
-    const result = await pipe(
+  describe('three item pipeline', () => {
+    it('should pipe iterable source -> transform -> sink function', () => {
+      const result = pipe(
+        oneTwoThree(),
+        function * (source) {
+          for (const n of source) {
+            yield n.toString()
+          }
+        },
+        (source) => all(source)
+      )
+
+      // @ts-expect-error - result should not be assignable to never - if it is
+      // then we've broken the types and this comment with cause tsc to fail
+      assertNotNever(result)
+      assertNotAny(result)
+
+      expect(result).to.deep.equal(['1', '2', '3'])
+    })
+
+    it('should pipe async iterable source -> async transform -> sink function', async () => {
+      const result = await pipe(
+        asyncOneTwoThree(),
+        async function * (source) {
+          for await (const n of source) {
+            yield n.toString()
+          }
+        },
+        async (source) => await all(source)
+      )
+
+      // @ts-expect-error - result should not be assignable to never - if it is
+      // then we've broken the types and this comment with cause tsc to fail
+      assertNotNever(result)
+      assertNotAny(result)
+
+      expect(result).to.deep.equal(['1', '2', '3'])
+    })
+
+    it('should pipe iterable source -> duplex -> sink function', () => {
+      const duplex: Duplex<number[], number[]> = {
+        sink: source => { duplex.source = source },
+        source: []
+      }
+
+      const result = pipe(
+        oneTwoThree,
+        duplex,
+        (source) => all(source)
+      )
+
+      expect(result[Symbol.iterator]).to.be.ok()
+      expect(result).to.deep.equal([1, 2, 3])
+    })
+
+    it('should pipe async iterable source -> duplex -> sink function', async () => {
+      const duplex: Duplex<AsyncGenerator<number>, AsyncGenerator<number>, void> = {
+        sink: source => { duplex.source = source },
+        source: (async function * () {}())
+      }
+
+      const result = await pipe(
+        asyncOneTwoThree(),
+        duplex,
+        async (source) => await all(source)
+      )
+
+      // @ts-expect-error - result should not be assignable to never - if it is
+      // then we've broken the types and this comment with cause tsc to fail
+      assertNotNever(result)
+      assertNotAny(result)
+
+      expect(result).to.deep.equal([1, 2, 3])
+    })
+  })
+
+  it('should pipe source -> transform -> sink', () => {
+    const result = pipe(
       oneTwoThree,
-      function transform (source) {
-        return (async function * () { // A generator is async iterable
-          for await (const val of source) yield val * 2
-        })()
+      function * transform (source) {
+        for (const val of source) {
+          yield val * 2
+        }
       },
-      all
+      (source) => all(source)
     )
 
+    expect(result[Symbol.iterator]).to.be.ok()
     expect(result).to.deep.equal([2, 4, 6])
   })
 
-  it('should allow iterable first param', async () => {
-    const result = await pipe(oneTwoThree(), all)
+  it('should pipe source -> async transform -> sink', async () => {
+    const result = await pipe(
+      oneTwoThree,
+      async function * transform (source) {
+        for await (const val of source) {
+          yield val * 2
+        }
+      },
+      async (source) => await all(source)
+    )
+
+    expect(result[Symbol.iterator]).to.be.ok()
+    expect(result).to.deep.equal([2, 4, 6])
+  })
+
+  it('should allow iterable first param', () => {
+    const result = pipe(
+      oneTwoThree(),
+      (source) => all(source)
+    )
+
+    expect(result[Symbol.iterator]).to.be.ok()
     expect(result).to.deep.equal([1, 2, 3])
+  })
+
+  it('should allow async iterable first param', async () => {
+    const result = pipe(
+      (async function * () {
+        yield * oneTwoThree()
+      }()),
+      async (source) => await all(source)
+    )
+
+    expect(result.then).to.be.ok()
+    await expect(result).to.eventually.deep.equal([1, 2, 3])
   })
 
   it('should allow duplex at start', async () => {
-    const duplex: Duplex<number, number, Promise<number[]>> = {
+    const duplex = {
       sink: all,
       source: oneTwoThree()
     }
 
-    const result = await pipe(duplex, all)
+    const result = pipe(
+      duplex,
+      (source) => all(source)
+    )
+
+    expect(result[Symbol.iterator]).to.be.ok()
     expect(result).to.deep.equal([1, 2, 3])
+  })
+
+  it('should allow async duplex at start', async () => {
+    const duplex: Duplex<AsyncIterable<number>, number[]> = {
+      sink: all,
+      source: asyncOneTwoThree()
+    }
+
+    const result = pipe(
+      duplex,
+      async (source) => await all(source)
+    )
+
+    expect(result.then).to.be.ok()
+    await expect(result).to.eventually.deep.equal([1, 2, 3])
   })
 
   it('should allow duplex at end', async () => {
-    const duplex: Duplex<number, number, Promise<number[]>> = {
-      sink: all,
+    const duplex = {
+      sink: (source: number[]) => all(source),
       source: oneTwoThree()
     }
 
-    const result = await pipe(oneTwoThree, duplex)
-    expect(result).to.deep.equal([1, 2, 3])
-  })
+    const result = pipe(oneTwoThree, duplex)
 
-  it('should allow duplex in the middle', async () => {
-    const duplex: Duplex<number, number, Promise<void>> = {
-      sink: async source => { duplex.source = source },
-      source: []
-    }
-
-    const result = await pipe(oneTwoThree, duplex, all)
+    expect(result[Symbol.iterator]).to.be.ok()
     expect(result).to.deep.equal([1, 2, 3])
   })
 
@@ -84,7 +369,7 @@ describe('it-pipe', () => {
   it('should allow it-drain', async () => {
     const input = [0, 1, 2, 3]
 
-    const result = await pipe(
+    const result = await pipe( // eslint-disable-line @typescript-eslint/no-confusing-void-expression
       input,
       (source) => source,
       filter((val: number) => val > 1),
@@ -100,7 +385,7 @@ describe('it-pipe', () => {
     const result = await pipe(
       input,
       filter((val: number) => val > 1),
-      collect
+      async (source) => await collect(source)
     )
 
     expect(result).to.deep.equal([2, 3])
@@ -109,11 +394,10 @@ describe('it-pipe', () => {
   it('should allow streaming iterables consume', async () => {
     const input = [0, 1, 2, 3]
 
-    const result = await pipe(
+    const result = await pipe( // eslint-disable-line @typescript-eslint/no-confusing-void-expression
       input,
       filter((val: number) => val > 1),
-      // @ts-expect-error https://github.com/reconbot/streaming-iterables/issues/232
-      (source) => consume(source)
+      async (source) => { await consume(source) }
     )
 
     expect(result).to.be.undefined()
@@ -125,7 +409,7 @@ describe('it-pipe', () => {
     await expect(
       pipe(
         oneTwoThree, {
-          source: (async function * () {
+          source: (async function * (): AsyncGenerator<number> {
             await delay(1000)
             yield 5
           }()),
@@ -134,7 +418,7 @@ describe('it-pipe', () => {
             throw err
           }
         },
-        async (source) => await drain(source)
+        async (source) => { await drain(source) }
       )
     ).to.eventually.be.rejected.with.property('message', err.message)
   })
@@ -181,7 +465,7 @@ describe('it-pipe', () => {
       await delay(1)
       yield * data
     }())
-    const output: Duplex<string, number> = {
+    const output: Duplex<string[], AsyncIterable<number>, Promise<void>> = {
       source: ['hello', 'world'],
       sink: async (source) => {
         collected.resolve(await all(source))

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -40,7 +40,7 @@ describe('it-pipe', () => {
       const result = pipe(oneTwoThree())
 
       // @ts-expect-error - result should not be assignable to never - if it is
-      // then we've broken the types and this comment with cause tsc to fail
+      // then we've broken the types and this comment will cause tsc to fail
       assertNotNever(result)
       assertNotAny(result)
 
@@ -52,7 +52,7 @@ describe('it-pipe', () => {
       const result = pipe(oneTwoThree)
 
       // @ts-expect-error - result should not be assignable to never - if it is
-      // then we've broken the types and this comment with cause tsc to fail
+      // then we've broken the types and this comment will cause tsc to fail
       assertNotNever(result)
       assertNotAny(result)
 
@@ -64,7 +64,7 @@ describe('it-pipe', () => {
       const result = pipe(asyncOneTwoThree())
 
       // @ts-expect-error - result should not be assignable to never - if it is
-      // then we've broken the types and this comment with cause tsc to fail
+      // then we've broken the types and this comment will cause tsc to fail
       assertNotNever(result)
       assertNotAny(result)
 
@@ -76,7 +76,7 @@ describe('it-pipe', () => {
       const result = pipe(asyncOneTwoThree)
 
       // @ts-expect-error - result should not be assignable to never - if it is
-      // then we've broken the types and this comment with cause tsc to fail
+      // then we've broken the types and this comment will cause tsc to fail
       assertNotNever(result)
       assertNotAny(result)
 
@@ -117,7 +117,7 @@ describe('it-pipe', () => {
       )
 
       // @ts-expect-error - result should not be assignable to never - if it is
-      // then we've broken the types and this comment with cause tsc to fail
+      // then we've broken the types and this comment will cause tsc to fail
       assertNotNever(result)
       assertNotAny(result)
 
@@ -134,7 +134,7 @@ describe('it-pipe', () => {
       )
 
       // @ts-expect-error - result should not be assignable to never - if it is
-      // then we've broken the types and this comment with cause tsc to fail
+      // then we've broken the types and this comment will cause tsc to fail
       assertNotNever(result)
       assertNotAny(result)
 
@@ -148,7 +148,7 @@ describe('it-pipe', () => {
       )
 
       // @ts-expect-error - result should not be assignable to never - if it is
-      // then we've broken the types and this comment with cause tsc to fail
+      // then we've broken the types and this comment will cause tsc to fail
       assertNotNever(result)
       assertNotAny(result)
 
@@ -162,7 +162,7 @@ describe('it-pipe', () => {
       )
 
       // @ts-expect-error - result should not be assignable to never - if it is
-      // then we've broken the types and this comment with cause tsc to fail
+      // then we've broken the types and this comment will cause tsc to fail
       assertNotNever(result)
       assertNotAny(result)
 
@@ -176,7 +176,7 @@ describe('it-pipe', () => {
       )
 
       // @ts-expect-error - result should not be assignable to never - if it is
-      // then we've broken the types and this comment with cause tsc to fail
+      // then we've broken the types and this comment will cause tsc to fail
       assertNotNever(result)
       assertNotAny(result)
 
@@ -197,7 +197,7 @@ describe('it-pipe', () => {
       )
 
       // @ts-expect-error - result should not be assignable to never - if it is
-      // then we've broken the types and this comment with cause tsc to fail
+      // then we've broken the types and this comment will cause tsc to fail
       assertNotNever(result)
       assertNotAny(result)
 
@@ -216,7 +216,7 @@ describe('it-pipe', () => {
       )
 
       // @ts-expect-error - result should not be assignable to never - if it is
-      // then we've broken the types and this comment with cause tsc to fail
+      // then we've broken the types and this comment will cause tsc to fail
       assertNotNever(result)
       assertNotAny(result)
 
@@ -235,6 +235,11 @@ describe('it-pipe', () => {
         (source) => all(source)
       )
 
+      // @ts-expect-error - result should not be assignable to never - if it is
+      // then we've broken the types and this comment will cause tsc to fail
+      assertNotNever(result)
+      assertNotAny(result)
+
       expect(result[Symbol.iterator]).to.be.ok()
       expect(result).to.deep.equal([1, 2, 3])
     })
@@ -252,7 +257,7 @@ describe('it-pipe', () => {
       )
 
       // @ts-expect-error - result should not be assignable to never - if it is
-      // then we've broken the types and this comment with cause tsc to fail
+      // then we've broken the types and this comment will cause tsc to fail
       assertNotNever(result)
       assertNotAny(result)
 


### PR DESCRIPTION
Crossing async boundaries is not free, so when this module is passed synchronous pipeline stages, do not wrap them in async generators to keep them synchronous.

BREAKING CHANGE: when the entire pipeline is synchronous, the return value will now be synchronous