### PR TITLE
fix: reuse types from it-stream-types to simplify

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,15 +149,15 @@
   },
   "dependencies": {
     "it-merge": "^3.0.0",
-    "it-pushable": "^3.1.0"
+    "it-pushable": "^3.1.2",
+    "it-stream-types": "^2.0.1"
   },
   "devDependencies": {
     "aegir": "^38.1.8",
     "delay": "^5.0.0",
-    "it-all": "^3.0.0",
-    "it-drain": "^3.0.0",
-    "it-map": "^3.0.0",
-    "it-stream-types": "^1.0.3",
+    "it-all": "^3.0.1",
+    "it-drain": "^3.0.1",
+    "it-map": "^3.0.2",
     "p-defer": "^4.0.0",
     "streaming-iterables": "^7.0.4"
   }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -6,8 +6,7 @@ import map from 'it-map'
 import { filter, collect, consume } from 'streaming-iterables'
 import delay from 'delay'
 import defer from 'p-defer'
-import type { Source } from 'it-stream-types'
-import type { Duplex } from '../src/index.js'
+import type { Source, Duplex } from 'it-stream-types'
 
 const oneTwoThree = (): number[] => [1, 2, 3]
 
@@ -224,7 +223,7 @@ describe('it-pipe', () => {
     })
 
     it('should pipe iterable source -> duplex -> sink function', () => {
-      const duplex: Duplex<number[], number[]> = {
+      const duplex: Duplex<number[], number[], void> = {
         sink: source => { duplex.source = source },
         source: []
       }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -223,7 +223,7 @@ describe('it-pipe', () => {
     })
 
     it('should pipe iterable source -> duplex -> sink function', () => {
-      const duplex: Duplex<number[], number[], void> = {
+      const duplex: Duplex<number[], number[]> = {
         sink: source => { duplex.source = source },
         source: []
       }


### PR DESCRIPTION
Removes the sync/async types for pipe source/sink functions as they are redundant.

Reuses the duplex/transform/sink interfaces from it-stream-types